### PR TITLE
resize iram/dram

### DIFF
--- a/components/esp32/ld/esp32.ld
+++ b/components/esp32/ld/esp32.ld
@@ -47,7 +47,7 @@ MEMORY
   are connected to the data port of the CPU and eg allow bytewise access. */
 
   /* IRAM for PRO cpu. Not sure if happy with this, this is MMU area... */
-  iram0_0_seg (RX) :                 org = 0x40080000, len = 0x20000
+  iram0_0_seg (RX) :                 org = 0x40080000, len = 0x30000
 
 #ifdef CONFIG_APP_BUILD_USE_FLASH_SECTIONS
   /* Even though the segment name is iram, it is actually mapped to flash

--- a/components/soc/esp32/include/soc/soc.h
+++ b/components/soc/esp32/include/soc/soc.h
@@ -246,7 +246,8 @@
 #define SOC_CACHE_APP_LOW       0x40078000
 #define SOC_CACHE_APP_HIGH      0x40080000
 #define SOC_IRAM_LOW            0x40080000
-#define SOC_IRAM_HIGH           0x400A0000
+//#define SOC_IRAM_HIGH           0x400A0000
+#define SOC_IRAM_HIGH           0x400B0000
 #define SOC_RTC_IRAM_LOW        0x400C0000
 #define SOC_RTC_IRAM_HIGH       0x400C2000
 #define SOC_RTC_DRAM_LOW        0x3FF80000
@@ -257,7 +258,8 @@
 #define SOC_EXTRAM_DATA_HIGH    0x3FC00000
 
 //First and last words of the D/IRAM region, for both the DRAM address as well as the IRAM alias.
-#define SOC_DIRAM_IRAM_LOW    0x400A0000
+//#define SOC_DIRAM_IRAM_LOW    0x400A0000
+#define SOC_DIRAM_IRAM_LOW    0x400B0000
 #define SOC_DIRAM_IRAM_HIGH   0x400C0000
 #define SOC_DIRAM_DRAM_LOW    0x3FFE0000
 #define SOC_DIRAM_DRAM_HIGH   0x40000000

--- a/components/soc/esp32/soc_memory_layout.c
+++ b/components/soc/esp32/soc_memory_layout.c
@@ -102,9 +102,9 @@ const soc_memory_region_t soc_memory_regions[] = {
     { 0x3FFE0000, 0x4000, 1, 0x400BC000}, //pool 9 blk 1
     { 0x3FFE4000, 0x4000, 1, 0x400B8000}, //pool 9 blk 0
     { 0x3FFE8000, 0x8000, 1, 0x400B0000}, //pool 8 <- can be remapped to ROM, used for MAC dump
-    { 0x3FFF0000, 0x8000, 1, 0x400A8000}, //pool 7 <- can be used for MAC dump
-    { 0x3FFF8000, 0x4000, 1, 0x400A4000}, //pool 6 blk 1 <- can be used as trace memory
-    { 0x3FFFC000, 0x4000, 1, 0x400A0000}, //pool 6 blk 0 <- can be used as trace memory
+//    { 0x3FFF0000, 0x8000, 1, 0x400A8000}, //pool 7 <- can be used for MAC dump
+//    { 0x3FFF8000, 0x4000, 1, 0x400A4000}, //pool 6 blk 1 <- can be used as trace memory
+//    { 0x3FFFC000, 0x4000, 1, 0x400A0000}, //pool 6 blk 0 <- can be used as trace memory
     { 0x40070000, 0x8000, 2, 0}, //pool 0
     { 0x40078000, 0x8000, 2, 0}, //pool 1
     { 0x40080000, 0x2000, 2, 0}, //pool 2-5, mmu page 0


### PR DESCRIPTION
Adjust IRAM/DRAM ration - take 64k from DRAM to add to IRAM. Additional IRAM is required for raccoon for bluetooth stack